### PR TITLE
Use psycopg2's copy_expert so we can copy from a local file to a remote database.

### DIFF
--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -83,7 +83,8 @@ class CopyMapping(object):
         # Run all of the raw SQL
         cursor.execute(drop_sql)
         cursor.execute(create_sql)
-        cursor.execute(copy_sql)
+        fp = open(self.csv_path, 'r')
+        cursor.copy_expert(copy_sql, fp)
         cursor.execute(insert_sql)
         cursor.execute(drop_sql)
 
@@ -151,12 +152,11 @@ class CopyMapping(object):
         """
         sql = """
             COPY "%(db_table)s" (%(header_list)s)
-            FROM '%(csv_path)s'
+            FROM STDIN
             WITH CSV HEADER %(extra_options)s;
         """
         options = {
             'db_table': self.temp_table_name,
-            'csv_path': self.csv_path,
             'extra_options': '',
             'header_list': ", ".join([
                 '"%s"' % h for f, h in self.field_header_crosswalk

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
     url='http://www.github.com/california-civic-data-coalition/django-postgresql-copy/',
     license="MIT",
     packages=("postgres_copy",),
+    install_requires=(
+        'psycopg2>=2.5',
+    ),
     cmdclass={'test': TestCommand},
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
psycopg2, powers the 2 supported PostgreSQL databases engines, has a [`copy_expert` method](http://initd.org/psycopg/docs/cursor.html?highlight=copy_expert#cursor.copy_expert) which takes a file-like object rather than a path. Using this method, we are able to execute the SQL copy using local csv file and a remote database. Using the regular `execute` method requires the file_path be on the same filesystem.