### PR TITLE
Remove call to intcomma

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,6 +160,11 @@ Keyword Arguments
 ``using``              Sets the database to use when importing data.
                        Default is None, which will use the ``'default'``
                        database.
+
+``static_column``      A dictionary: keys are strings corresponding to
+                       fields in the ``'model'``that are not in the source
+                       file. values are a (single) value that will be put
+                       into that field for every row in the source file
 =====================  =====================================================
 
 

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -2,8 +2,6 @@ import os
 import sys
 import csv
 from django.db import connections, router
-from django.contrib.humanize.templatetags.humanize import intcomma
-
 
 class CopyMapping(object):
     """
@@ -90,7 +88,7 @@ class CopyMapping(object):
 
         if not silent:
             stream.write(
-                "%s records loaded\n" % intcomma(self.model.objects.count())
+                "%s records loaded\n" % self.model.objects.count()
             )
 
     def get_headers(self):

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -3,6 +3,7 @@ import sys
 import csv
 from django.db import connections, router
 
+
 class CopyMapping(object):
     """
     Maps comma-delimited data file to a Django model

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -2,6 +2,7 @@ import os
 import sys
 import csv
 from django.db import connections, router
+from collections import OrderedDict
 
 
 class CopyMapping(object):
@@ -19,6 +20,7 @@ class CopyMapping(object):
         delimiter=',',
         null=None,
         encoding=None,
+        static_columns=None
     ):
         self.model = model
         self.mapping = mapping
@@ -37,6 +39,10 @@ class CopyMapping(object):
         self.delimiter = delimiter
         self.null = null
         self.encoding = encoding
+        if static_columns is not None:
+            self.static_columns = OrderedDict(static_columns)
+        else:
+            self.static_columns = {}
 
         # Connect the headers from the CSV with the fields on the model
         self.field_header_crosswalk = []
@@ -193,6 +199,8 @@ class CopyMapping(object):
                 model_fields.append('"%s"' % field.db_column)
             else:
                 model_fields.append('"%s"' % field.name)
+        for k in self.static_columns.keys():
+            model_fields.append('"%s"' % k)
         options['model_fields'] = ", ".join(model_fields)
 
         temp_fields = []
@@ -205,5 +213,7 @@ class CopyMapping(object):
                 template = getattr(self.model(), template_method)()
                 string = template % dict(name=header)
             temp_fields.append(string)
+        for v in self.static_columns.values():
+            temp_fields.append("'%s'" % v)
         options['temp_fields'] = ", ".join(temp_fields)
         return sql % options

--- a/tests/models.py
+++ b/tests/models.py
@@ -13,3 +13,18 @@ class MockObject(models.Model):
     def copy_name_template(self):
         return 'upper("%(name)s")'
     copy_name_template.copy_type = 'text'
+
+
+class ExtendedMockObject(models.Model):
+    static_val = models.IntegerField()
+    name = models.CharField(max_length=500)
+    number = MyIntegerField(null=True, db_column='num')
+    dt = models.DateField(null=True)
+    static_string = models.CharField(max_length=5)
+
+    class Meta:
+        app_label = 'tests'
+
+    def copy_name_template(self):
+        return 'upper("%(name)s")'
+    copy_name_template.copy_type = 'text'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,6 @@
 import os
 from datetime import date
-from .models import MockObject
+from .models import MockObject, ExtendedMockObject
 from postgres_copy import CopyMapping
 from django.test import TestCase
 
@@ -13,10 +13,10 @@ class PostgresCopyTest(TestCase):
         self.pipe_path = os.path.join(self.data_dir, 'pipes.csv')
         self.null_path = os.path.join(self.data_dir, 'nulls.csv')
         self.backwards_path = os.path.join(self.data_dir, 'backwards.csv')
-        self.baddates_path = os.path.join(self.data_dir, 'baddates.csv')
 
     def tearDown(self):
         MockObject.objects.all().delete()
+        ExtendedMockObject.objects.all().delete()
 
     def test_bad_call(self):
         with self.assertRaises(TypeError):
@@ -157,3 +157,15 @@ class PostgresCopyTest(TestCase):
             MockObject.objects.get(name='BEN').dt,
             date(2012, 1, 1)
         )
+
+    def test_static_values(self):
+        c = CopyMapping(
+            ExtendedMockObject,
+            self.name_path,
+            dict(name='NAME', number='NUMBER', dt='DATE'),
+            encoding='UTF-8',
+            static_columns={'static_val':1,'static_string':'test'}
+        )
+        c.save()
+        self.assertEqual(ExtendedMockObject.objects.filter(static_val = 1).count(), 3)
+        self.assertEqual(ExtendedMockObject.objects.filter(static_string = 'test').count(), 3)


### PR DESCRIPTION
intcomma was throwing a typeerror. Since it was a pretty-print
nicety it has been removed. close #16