### PR TITLE
Remove call to intcomma 

### DIFF
--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -2,7 +2,6 @@ import os
 import sys
 import csv
 from django.db import connections, router
-from django.contrib.humanize.templatetags.humanize import intcomma
 
 
 class CopyMapping(object):
@@ -90,7 +89,7 @@ class CopyMapping(object):
 
         if not silent:
             stream.write(
-                "%s records loaded\n" % intcomma(self.model.objects.count())
+                "%s records loaded\n" % self.model.objects.count()
             )
 
     def get_headers(self):


### PR DESCRIPTION
intcomma was throwing a typeerror. Since it was a pretty-print
nicety it has been removed. close #16 
Updated as one commit