### PR TITLE
Add static_column kwarg to CopyMapping for one-off values not in sour…

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,6 +160,11 @@ Keyword Arguments
 ``using``              Sets the database to use when importing data.
                        Default is None, which will use the ``'default'``
                        database.
+
+``static_column``      A dictionary: keys are strings corresponding to
+                       fields in the ``'model'`` that are not in the source
+                       file. values are a (single) value that will be put
+                       into that field for every row in the source file
 =====================  =====================================================
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -13,3 +13,18 @@ class MockObject(models.Model):
     def copy_name_template(self):
         return 'upper("%(name)s")'
     copy_name_template.copy_type = 'text'
+
+
+class ExtendedMockObject(models.Model):
+    static_val = models.IntegerField()
+    name = models.CharField(max_length=500)
+    number = MyIntegerField(null=True, db_column='num')
+    dt = models.DateField(null=True)
+    static_string = models.CharField(max_length=5)
+
+    class Meta:
+        app_label = 'tests'
+
+    def copy_name_template(self):
+        return 'upper("%(name)s")'
+    copy_name_template.copy_type = 'text'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,6 @@
 import os
 from datetime import date
-from .models import MockObject
+from .models import MockObject, ExtendedMockObject
 from postgres_copy import CopyMapping
 from django.test import TestCase
 
@@ -13,10 +13,10 @@ class PostgresCopyTest(TestCase):
         self.pipe_path = os.path.join(self.data_dir, 'pipes.csv')
         self.null_path = os.path.join(self.data_dir, 'nulls.csv')
         self.backwards_path = os.path.join(self.data_dir, 'backwards.csv')
-        self.baddates_path = os.path.join(self.data_dir, 'baddates.csv')
 
     def tearDown(self):
         MockObject.objects.all().delete()
+        ExtendedMockObject.objects.all().delete()
 
     def test_bad_call(self):
         with self.assertRaises(TypeError):
@@ -157,3 +157,15 @@ class PostgresCopyTest(TestCase):
             MockObject.objects.get(name='BEN').dt,
             date(2012, 1, 1)
         )
+
+    def test_static_values(self):
+        c = CopyMapping(
+            ExtendedMockObject,
+            self.name_path,
+            dict(name='NAME', number='NUMBER', dt='DATE'),
+            encoding='UTF-8',
+            static_columns={'static_val':1,'static_string':'test'}
+        )
+        c.save()
+        self.assertEqual(ExtendedMockObject.objects.filter(static_val = 1).count(), 3)
+        self.assertEqual(ExtendedMockObject.objects.filter(static_string = 'test').count(), 3)


### PR DESCRIPTION
…ce file

This allows for fields in the model but not in the source file
to be populated with a one-off field.
An example use case is to track the originator of data. Instead
of the incoming data needing a duplicate field in every row
the copy process can include something like
static_columns={'originator':some_local_lookup_for_originator()}