### PR TITLE
Overload column

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -143,31 +143,36 @@ Argument           Description
                    string field names for the CSV header.
 =================  =========================================================
 
-=====================  =====================================================
+=======================  =====================================================
 Keyword Arguments
-=====================  =====================================================
-``delimiter``          The character that separates values in the data file.
-                       By default  it is ",". This must be a single one-byte
-                       character.
+=======================  =====================================================
+``delimiter``            The character that separates values in the data file.
+                         By default  it is ",". This must be a single one-byte
+                         character.
 
-``null``               Specifies the string that represents a null value.
-                       The default is an unquoted empty string. This must
-                       be a single one-byte character.
+``null``                 Specifies the string that represents a null value.
+                         The default is an unquoted empty string. This must
+                         be a single one-byte character.
 
-``encoding``           Specifies the character set encoding of the strings
-                       in the CSV data source.  For example, ``'latin-1'``,
-                       ``'utf-8'``, and ``'cp437'`` are all valid encoding
-                       parameters.
+``encoding``             Specifies the character set encoding of the strings
+                         in the CSV data source.  For example, ``'latin-1'``,
+                         ``'utf-8'``, and ``'cp437'`` are all valid encoding
+                         parameters.
 
-``using``              Sets the database to use when importing data.
-                       Default is None, which will use the ``'default'``
-                       database.
+``using``                Sets the database to use when importing data.
+                         Default is None, which will use the ``'default'``
+                         database.
 
-``static_mapping``     Set model attributes not in the CSV the same
-                       for every row in the database by providing a dictionary
-                       with the name of the columns as keys and the static
-                       inputs as values.
-=====================  =====================================================
+``static_mapping``       Set model attributes not in the CSV the same
+                         for every row in the database by providing a dictionary
+                         with the name of the columns as keys and the static
+                         inputs as values.
+
+``overloaded_mapping``   Reuse a mapped column for a different model field.
+                         This is useful when you want to have both the
+                         original value as well as a modified form, generally
+                         using a `copy_template` to transform the second value
+=======================  =====================================================
 
 
 ``save()`` keyword arguments

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -189,8 +189,8 @@ class CopyMapping(object):
             'db_table': self.temp_table_name,
             'extra_options': '',
             'header_list': ", ".join([
-                                         '"%s"' % h for f, h in self.field_header_crosswalk
-                                         ])
+                '"%s"' % h for f, h in self.field_header_crosswalk
+             ])
         }
         if self.delimiter:
             options['extra_options'] += " DELIMITER '%s'" % self.delimiter

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -74,7 +74,7 @@ class CopyMapping(object):
             if v not in inverse_mapping.keys():
                 raise ValueError("Overloaded %s field is not in mapping" % k)
             try:
-                f = [f for f in self.model._meta.fields if f.name == k][0]
+                o = [o for o in self.model._meta.fields if o.name == k][0]
             except IndexError:
                 raise ValueError("Model does not include overload %s field"
                                  % v)

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -71,8 +71,6 @@ class CopyMapping(object):
                 raise ValueError("Model does not include %s field" % f_name)
         # Validate Overloaded headers and fields
         for k, v in self.overloaded_mapping.items():
-            if v not in inverse_mapping.keys():
-                raise ValueError("Overloaded %s field is not in mapping" % k)
             try:
                 [o for o in self.model._meta.fields if o.name == k][0]
             except IndexError:

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -74,7 +74,7 @@ class CopyMapping(object):
             if v not in inverse_mapping.keys():
                 raise ValueError("Overloaded %s field is not in mapping" % k)
             try:
-                o = [o for o in self.model._meta.fields if o.name == k][0]
+                [o for o in self.model._meta.fields if o.name == k][0]
             except IndexError:
                 raise ValueError("Model does not include overload %s field"
                                  % v)

--- a/tests/models.py
+++ b/tests/models.py
@@ -29,3 +29,23 @@ class ExtendedMockObject(models.Model):
     def copy_name_template(self):
         return 'upper("%(name)s")'
     copy_name_template.copy_type = 'text'
+
+
+class OverloadMockObject(models.Model):
+    name = models.CharField(max_length=500)
+    lower_name = models.CharField(max_length=500)
+    number = MyIntegerField(null=True, db_column='num')
+    dt = models.DateField(null=True)
+    parent = models.ForeignKey('MockObject', null=True, default=None)
+
+    class Meta:
+        app_label = 'tests'
+
+    def copy_name_template(self):
+        return 'upper("%(name)s")'
+    copy_name_template.copy_type = 'text'
+
+    def copy_lower_name_template(self):
+        return 'lower("%(name)s")'
+    copy_name_template.copy_type = 'text'
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -237,16 +237,7 @@ class PostgresCopyTest(TestCase):
         omo = OverloadMockObject.objects.first()
         self.assertEqual(omo.name.lower(), omo.lower_name)
 
-    def test_bad_non_overload(self):
-        with self.assertRaises(ValueError):
-            c = CopyMapping(
-                OverloadMockObject,
-                self.name_path,
-                dict(name='NAME', dt='DATE'),
-                static_mapping=dict(number=12),
-                overloaded_mapping=dict(number='NUMBER')
-            )
-
+    def test_missing_overload_field(self):
         with self.assertRaises(ValueError):
             c = CopyMapping(
                 OverloadMockObject,
@@ -254,4 +245,3 @@ class PostgresCopyTest(TestCase):
                 dict(name='NAME', number='NUMBER', dt='DATE'),
                 overloaded_mapping=dict(missing='NAME')
             )
-


### PR DESCRIPTION
I wanted the ability to have two fields in my model to map to the same incoming data column. The second of the two fields is a transformation of the data. COPY with copy_templates runs quickly as compared to updating all the rows after a copy, and denormalizing is preferred for my use case I added this feature.
I thought it was better to be explicit with a new kwarg for overloaded_mapping as opposed to allowing multiple instances of a column in the mapping parameter.