### PR TITLE
fix project name in setup url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
 using PostgreSQL's COPY command",
     author='Ben Welsh',
     author_email='ben.welsh@gmail.com',
-    url='http://www.github.com/california-civic-data-coalition/django-postgresql-copy/',
+    url='http://www.github.com/california-civic-data-coalition/django-postgres-copy/',
     license="MIT",
     packages=("postgres_copy",),
     install_requires=(),


### PR DESCRIPTION
s/django-postgresql-copy/django-postgres-copy/

If you'd rather just make this change later whenever you next have to bump setup, please feel free to close without merging...

Thanks for sharing your code!