### PR TITLE
FORCE NOT NULL and FORCE NULL support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
  - "2.7"
  - "3.6"
 
+addons:
+ postgresql: "9.4"
+
 env:
  - DJANGO_VERSION=1.8.18
  - DJANGO_VERSION=1.10.7

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,7 +117,7 @@ Like I said, that's it!
 ``CopyMapping`` API
 -------------------
 
-.. class:: CopyMapping(model, csv_path, mapping[, using=None, delimiter=',', null=None, encoding=None, static_mapping=None])
+.. class:: CopyMapping(model, csv_path, mapping[, using=None, delimiter=',', null=None, force_not_null=None, force_null=None, encoding=None, static_mapping=None])
 
 The following are the arguments and keywords that may be used during
 instantiation of ``CopyMapping`` objects.
@@ -149,6 +149,19 @@ Keyword Arguments
 ``null``               Specifies the string that represents a null value.
                        The default is an unquoted empty string. This must
                        be a single one-byte character.
+
+``force_not_null``     Specifies which columns that should ignore matches
+                       against the null string. Empty values in these columns
+                       will remain zero-length strings rather than becoming
+                       nulls. The default is None. If passed, this must be
+                       list of column names.
+
+``force_null``         Specifies which columns that should register matches
+                       against the null string, even if it has been quoted.
+                       In the default case where the null string is empty,
+                       this converts a quoted empty string into NULL. The
+                       default is None. If passed, this must be list of
+                       column names.
 
 ``encoding``           Specifies the character set encoding of the strings
                        in the CSV data source.  For example, ``'latin-1'``,

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -24,6 +24,8 @@ class CopyMapping(object):
         delimiter=',',
         quote_character=None,
         null=None,
+        force_not_null=None,
+        force_null=None,
         encoding=None,
         static_mapping=None
     ):
@@ -38,6 +40,8 @@ class CopyMapping(object):
         self.quote_character = quote_character
         self.delimiter = delimiter
         self.null = null
+        self.force_not_null = force_not_null
+        self.force_null = force_null
         self.encoding = encoding
         if static_mapping is not None:
             self.static_mapping = OrderedDict(static_mapping)
@@ -202,6 +206,10 @@ class CopyMapping(object):
             options['extra_options'] += " DELIMITER '%s'" % self.delimiter
         if self.null is not None:
             options['extra_options'] += " NULL '%s'" % self.null
+        if self.force_not_null is not None:
+            options['extra_options'] += " FORCE NOT NULL %s" % ','.join('"%s"' % s for s in self.force_not_null)
+        if self.force_null is not None:
+            options['extra_options'] += " FORCE NULL %s" % ','.join('"%s"' % s for s in self.force_null)
         if self.encoding:
             options['extra_options'] += " ENCODING '%s'" % self.encoding
         return sql % options

--- a/tests/data/blanknulls.csv
+++ b/tests/data/blanknulls.csv
@@ -1,0 +1,6 @@
+NAME,NUMBER,DATE,COLOR
+ben,1,2012-01-01,red
+joe,2,2012-01-02,green
+jane,3,2012-01-03,orange
+nullboy,,2012-01-04,
+badboy,x,2012-01-05,blue

--- a/tests/models.py
+++ b/tests/models.py
@@ -16,6 +16,20 @@ class MockObject(models.Model):
         return 'upper("%(name)s")'
 
 
+class MockBlankObject(models.Model):
+    name = models.CharField(max_length=500)
+    number = MyIntegerField(null=True, db_column='num')
+    dt = models.DateField(null=True)
+    color = models.CharField(max_length=50, blank=True)
+    parent = models.ForeignKey('MockObject', null=True, default=None)
+
+    class Meta:
+        app_label = 'tests'
+
+    def copy_name_template(self):
+        return 'upper("%(name)s")'
+
+
 class ExtendedMockObject(models.Model):
     static_val = models.IntegerField()
     name = models.CharField(max_length=500)


### PR DESCRIPTION
This resolves #44 and adds support for `force_not_null` and `force_null` options to `CopyMapping`.

I followed the same format as the other `extra_options` — but these two are a little bit more complicated because they need to support the passing of lists. Let me know if you think it should be a bit more robust!

I was able to reuse one of the other test fixtures for `force_null`, but none of the mocks fit what `force_not_null` is trying to accomplish, so I created a new mock and CSV for it.

I also *think* I correctly updated the documentation too, but I have little experience with Sphinx so I was kind of winging it. 😬 

I've been testing this against an internal app and it solved my original issue. 🎉 