### PR TITLE
Add null_string kwarg to .to_csv().

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -462,6 +462,9 @@ Argument           Description
                    file.
 
 ``with_header``    Boolean determines if the header should be exported
+
+``null_string``    String to populate exported null values with. Default
+                   is an empty string.
 =================  =========================================================
 
 Reducing the exported fields

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -27,6 +27,8 @@ class CopyQuerySet(models.QuerySet):
         query.copy_to_delimiter = kwargs.get('delimiter', ',')
         with_header = kwargs.get('with_header', True)
         query.copy_to_header = "HEADER" if with_header else ""
+        null_string = kwargs.get('with_header', None)
+        query.copy_to_null_string = "" if null_string is None else "NULL '%s'" % null_string
         compiler = query.get_compiler(self.db, connection=connection)
         compiler.execute_sql(csv_path)
 

--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -49,8 +49,9 @@ class SQLCopyToCompiler(SQLCompiler):
                 select_sql = self.as_sql()[0] % adapted_params
                 # then the COPY TO query
                 copy_to_sql = (
-                    "COPY (%s) TO STDOUT DELIMITER '%s' CSV %s"
-                ) % (select_sql, self.query.copy_to_delimiter, self.query.copy_to_header)
+                    "COPY (%s) TO STDOUT DELIMITER '%s' CSV %s %s"
+                ) % (select_sql, self.query.copy_to_delimiter, self.query.copy_to_header,
+                     self.query.copy_to_null_string)
                 # then execute
                 c.cursor.copy_expert(copy_to_sql, stdout)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -96,6 +96,24 @@ class PostgresCopyToTest(BaseTest):
             [i['name'] for i in reader]
         )
 
+    def test_export_null_string(self):
+        self._load_objects(self.blank_null_path)
+        MockObject.objects.to_csv(self.export_path)
+        self.assertTrue(os.path.exists(self.export_path))
+        reader = csv.DictReader(open(self.export_path, 'r'))
+        self.assertTrue(
+            ['1', '2', '3', '', ''],
+            [i['num'] for i in reader]
+        )
+
+        MockObject.objects.to_csv(self.export_path, null_string='NULL')
+        self.assertTrue(os.path.exists(self.export_path))
+        reader = csv.DictReader(open(self.export_path, 'r'))
+        self.assertTrue(
+            ['1', '2', '3', 'NULL', ''],
+            [i['num'] for i in reader]
+        )
+
     def test_filter(self):
         self._load_objects(self.name_path)
         MockObject.objects.filter(name="BEN").to_csv(self.export_path)


### PR DESCRIPTION
This will populate null values in export with the provided string. Defaults to
postgres standard of the unquoted empty string. (Issue #49)