### PR TITLE
Introduce methods that can be used without using manager

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,13 @@
+The following people have contributed to django-postgres-copy
+
+Ben Welsh (palewire)
+Chaim Kirby (ckirby)
+James Gordon (gordonje)
+Ryan Murphy (rdmurphy)
+Magnum Leno (magnunleno)
+Yury Paykov (ojomio)
+Douglas Denhartog (denhartog)
+Michael Corey (mikejcorey)
+Jonathan Barratt (reduxionist)
+Daniel Cloud (dcloud)
+Jonathan Sundqvist (jonathan-s)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,8 +46,20 @@ And here's how it exports a database table to a CSV.
 
     from myapp.models import MyModel
 
-
     MyModel.objects.to_csv("./data.csv")
+
+
+You can also use these methods standalone if you so need.
+
+.. code-block: python
+
+    from postgres_copy import from_csv
+    from myapp.models import MyModel
+
+    from_csv(MyModel, './data.csv', dict(name='NAME', number='NUMBER'))
+
+    query = MyModel.objects.all()
+    to_csv('./export.csv', query, db='default')
 
 
 Installation

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from .copy_from import CopyMapping
 from .copy_to import SQLCopyToCompiler, CopyToQuery
-from .managers import CopyManager, CopyQuerySet
+from .managers import CopyManager, CopyQuerySet, from_csv, to_csv
 __version__ = '2.3.0'
 
 
@@ -11,5 +11,7 @@ __all__ = (
     'CopyMapping',
     'CopyQuerySet',
     'CopyToQuery',
-    'SQLCopyToCompiler'
+    'SQLCopyToCompiler',
+    'from_csv',
+    'to_csv'
 )

--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -153,6 +153,7 @@ class CopyMapping(object):
 
         Raises errors if something goes wrong. Returns nothing if everything is kosher.
         """
+
         # Make sure all of the CSV headers in the mapping actually exist
         for map_header in self.mapping.values():
             if map_header not in self.headers:


### PR DESCRIPTION
This is a pretty useful library and sometimes you'd like to be able to just use a method to make the insertion without going through adding a new manager to your model. 

This should fix that use case. 