### PR TITLE
Add export option to use stdout instead of file for csv output

### DIFF
--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -57,18 +57,17 @@ class SQLCopyToCompiler(SQLCompiler):
             )
             # then execute
             logger.debug(copy_to_sql)
-            c.cursor.copy_expert(copy_to_sql, stdout)
 
-        if not csv_path:
-            stdout = BytesIO()
-            c.cursor.copy_expert(copy_to_sql, stdout)
-            return stdout.getvalue()
-        else:
-            # open file for writing
-            with open(csv_path, 'wb') as stdout:
+            if csv_path is None:
+                stdout = BytesIO()
                 c.cursor.copy_expert(copy_to_sql, stdout)
-                return
-
+                return stdout.getvalue()
+            else:
+                # open file for writing
+                with open(csv_path, 'wb') as stdout:
+                    c.cursor.copy_expert(copy_to_sql, stdout)
+                    return
+    
 
 class CopyToQuery(Query):
     """

--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -5,6 +5,7 @@ Handlers for working with PostgreSQL's COPY TO command.
 """
 from __future__ import unicode_literals
 import logging
+from io import BytesIO
 from django.db import connections
 from psycopg2.extensions import adapt
 from django.db.models.sql.query import Query
@@ -32,7 +33,7 @@ class SQLCopyToCompiler(SQLCompiler):
                     selection = (expression, self.compile(expression), None)
                 self.select.append(selection)
 
-    def execute_sql(self, csv_path):
+    def execute_sql(self, csv_path=None):
         """
         Run the COPY TO query.
         """
@@ -42,23 +43,31 @@ class SQLCopyToCompiler(SQLCompiler):
         params = self.as_sql()[1]
         adapted_params = tuple(adapt(p) for p in params)
 
-        # open file for writing
         # use stdout to avoid file permission issues
-        with open(csv_path, 'wb') as stdout:
-            with connections[self.using].cursor() as c:
-                # compile the SELECT query
-                select_sql = self.as_sql()[0] % adapted_params
-                # then the COPY TO query
-                copy_to_sql = "COPY ({}) TO STDOUT DELIMITER '{}' CSV {} {}"
-                copy_to_sql = copy_to_sql.format(
-                    select_sql,
-                    self.query.copy_to_delimiter,
-                    self.query.copy_to_header,
-                    self.query.copy_to_null_string
-                )
-                # then execute
-                logger.debug(copy_to_sql)
+        with connections[self.using].cursor() as c:
+            # compile the SELECT query
+            select_sql = self.as_sql()[0] % adapted_params
+            # then the COPY TO query
+            copy_to_sql = "COPY ({}) TO STDOUT DELIMITER '{}' CSV {} {}"
+            copy_to_sql = copy_to_sql.format(
+                select_sql,
+                self.query.copy_to_delimiter,
+                self.query.copy_to_header,
+                self.query.copy_to_null_string
+            )
+            # then execute
+            logger.debug(copy_to_sql)
+            c.cursor.copy_expert(copy_to_sql, stdout)
+
+        if not csv_path:
+            stdout = BytesIO()
+            c.cursor.copy_expert(copy_to_sql, stdout)
+            return stdout.getvalue()
+        else:
+            # open file for writing
+            with open(csv_path, 'wb') as stdout:
                 c.cursor.copy_expert(copy_to_sql, stdout)
+                return
 
 
 class CopyToQuery(Query):

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -147,7 +147,7 @@ class CopyQuerySet(ConstraintQuerySet):
 
         return insert_count
 
-    def to_csv(self, csv_path, *fields, **kwargs):
+    def to_csv(self, csv_path=None, *fields, **kwargs):
         """
         Copy current QuerySet to CSV at provided path.
         """
@@ -174,7 +174,8 @@ class CopyQuerySet(ConstraintQuerySet):
 
         # Run the query
         compiler = query.get_compiler(self.db, connection=connection)
-        compiler.execute_sql(csv_path)
-
+        data = compiler.execute_sql(csv_path)
+        if csv_path is None:
+            return data
 
 CopyManager = models.Manager.from_queryset(CopyQuerySet)


### PR DESCRIPTION
If csv_path is None, those modifications allow to return csv output as string using sdtout export instead of writing it to a file.
This allow to serve it from memory (for not very big files, of course).