### PR TITLE
Missing kwargs

### DIFF
--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -49,7 +49,7 @@ class SQLCopyToCompiler(SQLCompiler):
             # compile the SELECT query
             select_sql = self.as_sql()[0] % adapted_params
             # then the COPY TO query
-            copy_to_sql =
+            copy_to_sql = \
                 "COPY ({0}) TO STDOUT DELIMITER '{1}' CSV {2} {3} {4} {5} {6} {7}"
             copy_to_sql = copy_to_sql.format(
                 select_sql,                     #0

--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -50,7 +50,7 @@ class SQLCopyToCompiler(SQLCompiler):
             select_sql = self.as_sql()[0] % adapted_params
             # then the COPY TO query
             copy_to_sql =
-                "COPY ({0}) TO STDOUT DELIMITER '{1}' CSV {2} {3} {4} {5}"
+                "COPY ({0}) TO STDOUT DELIMITER '{1}' CSV {2} {3} {4} {5} {6}"
             copy_to_sql = copy_to_sql.format(
                 select_sql,                     #0
                 self.query.copy_to_delimiter,   #1
@@ -58,6 +58,7 @@ class SQLCopyToCompiler(SQLCompiler):
                 self.query.copy_to_null_string, #3
                 self.query.copy_to_quote_char,  #4
                 self.query.copy_to_force_quote, #5
+                self.query.copy_to_encoding,    #6
             )
             # then execute
             logger.debug(copy_to_sql)

--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -49,12 +49,13 @@ class SQLCopyToCompiler(SQLCompiler):
             # compile the SELECT query
             select_sql = self.as_sql()[0] % adapted_params
             # then the COPY TO query
-            copy_to_sql = "COPY ({}) TO STDOUT DELIMITER '{}' CSV {} {}"
+            copy_to_sql = "COPY ({}) TO STDOUT DELIMITER '{}' CSV {} {} {}"
             copy_to_sql = copy_to_sql.format(
                 select_sql,
                 self.query.copy_to_delimiter,
                 self.query.copy_to_header,
-                self.query.copy_to_null_string
+                self.query.copy_to_null_string,
+                self.query.copy_to_quote_char,
             )
             # then execute
             logger.debug(copy_to_sql)

--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -49,13 +49,14 @@ class SQLCopyToCompiler(SQLCompiler):
             # compile the SELECT query
             select_sql = self.as_sql()[0] % adapted_params
             # then the COPY TO query
-            copy_to_sql = "COPY ({}) TO STDOUT DELIMITER '{}' CSV {} {} {}"
+            copy_to_sql = "COPY ({}) TO STDOUT DELIMITER '{}' CSV {} {} {} {}"
             copy_to_sql = copy_to_sql.format(
                 select_sql,
                 self.query.copy_to_delimiter,
                 self.query.copy_to_header,
                 self.query.copy_to_null_string,
                 self.query.copy_to_quote_char,
+                self.query.copy_to_force_quote,
             )
             # then execute
             logger.debug(copy_to_sql)

--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -52,14 +52,14 @@ class SQLCopyToCompiler(SQLCompiler):
             copy_to_sql = \
                 "COPY ({0}) TO STDOUT DELIMITER '{1}' CSV {2} {3} {4} {5} {6} {7}"
             copy_to_sql = copy_to_sql.format(
-                select_sql,                     #0
-                self.query.copy_to_delimiter,   #1
-                self.query.copy_to_header,      #2
-                self.query.copy_to_null_string, #3
-                self.query.copy_to_quote_char,  #4
-                self.query.copy_to_force_quote, #5
-                self.query.copy_to_encoding,    #6
-                self.query.copy_to_escape,      #7
+                select_sql,                      # 0
+                self.query.copy_to_delimiter,    # 1
+                self.query.copy_to_header,       # 2
+                self.query.copy_to_null_string,  # 3
+                self.query.copy_to_quote_char,   # 4
+                self.query.copy_to_force_quote,  # 5
+                self.query.copy_to_encoding,     # 6
+                self.query.copy_to_escape,       # 7
             )
             # then execute
             logger.debug(copy_to_sql)

--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -50,7 +50,7 @@ class SQLCopyToCompiler(SQLCompiler):
             select_sql = self.as_sql()[0] % adapted_params
             # then the COPY TO query
             copy_to_sql =
-                "COPY ({0}) TO STDOUT DELIMITER '{1}' CSV {2} {3} {4} {5} {6}"
+                "COPY ({0}) TO STDOUT DELIMITER '{1}' CSV {2} {3} {4} {5} {6} {7}"
             copy_to_sql = copy_to_sql.format(
                 select_sql,                     #0
                 self.query.copy_to_delimiter,   #1
@@ -59,6 +59,7 @@ class SQLCopyToCompiler(SQLCompiler):
                 self.query.copy_to_quote_char,  #4
                 self.query.copy_to_force_quote, #5
                 self.query.copy_to_encoding,    #6
+                self.query.copy_to_escape,      #7
             )
             # then execute
             logger.debug(copy_to_sql)

--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -49,14 +49,15 @@ class SQLCopyToCompiler(SQLCompiler):
             # compile the SELECT query
             select_sql = self.as_sql()[0] % adapted_params
             # then the COPY TO query
-            copy_to_sql = "COPY ({}) TO STDOUT DELIMITER '{}' CSV {} {} {} {}"
+            copy_to_sql =
+                "COPY ({0}) TO STDOUT DELIMITER '{1}' CSV {2} {3} {4} {5}"
             copy_to_sql = copy_to_sql.format(
-                select_sql,
-                self.query.copy_to_delimiter,
-                self.query.copy_to_header,
-                self.query.copy_to_null_string,
-                self.query.copy_to_quote_char,
-                self.query.copy_to_force_quote,
+                select_sql,                     #0
+                self.query.copy_to_delimiter,   #1
+                self.query.copy_to_header,      #2
+                self.query.copy_to_null_string, #3
+                self.query.copy_to_quote_char,  #4
+                self.query.copy_to_force_quote, #5
             )
             # then execute
             logger.debug(copy_to_sql)

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -182,6 +182,10 @@ class CopyQuerySet(ConstraintQuerySet):
             "FORCE QUOTE {}".format(", ".join(column for column in force_quote))
             if force_quote else ""
 
+        # Encoding
+        set_encoding = kwargs.get('encoding', None)
+        query.copy_to_encoding = "ENCODING '{}'".format(set_encoding) if set_encoding else ""
+
         # Run the query
         compiler = query.get_compiler(self.db, connection=connection)
         data = compiler.execute_sql(csv_path)

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -178,9 +178,14 @@ class CopyQuerySet(ConstraintQuerySet):
 
         # Force quote on columns
         force_quote = kwargs.get('force_quote', None)
-        query.copy_to_force_quote =
-            "FORCE QUOTE {}".format(", ".join(column for column in force_quote))
-            if force_quote else ""
+        if force_quote:
+            if type(force_quote) == list:
+                query.copy_to_force_quote = \
+                    "FORCE QUOTE {}".format(", ".join(column for column in force_quote))
+            else:
+                query.copy_to_force_quote = "FORCE QUOTE {}".format(force_quote)
+        else:
+            query.copy_to_force_quote = ""
 
         # Encoding
         set_encoding = kwargs.get('encoding', None)

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -176,6 +176,12 @@ class CopyQuerySet(ConstraintQuerySet):
         quote_char = kwargs.get('quote', None)
         query.copy_to_quote_char = "QUOTE '{}'".format(quote_char) if quote_char else ""
 
+        # Force quote on columns
+        force_quote = kwargs.get('force_quote', None)
+        query.copy_to_force_quote =
+            "FORCE QUOTE {}".format(", ".join(column for column in force_quote))
+            if force_quote else ""
+
         # Run the query
         compiler = query.get_compiler(self.db, connection=connection)
         data = compiler.execute_sql(csv_path)

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -172,6 +172,10 @@ class CopyQuerySet(ConstraintQuerySet):
         null_string = kwargs.get('null', None)
         query.copy_to_null_string = "" if null_string is None else "NULL '{}'".format(null_string)
 
+        # Quote character
+        quote_char = kwargs.get('quote', None)
+        query.copy_to_quote_char = "QUOTE '{}'".format(quote_char) if quote_char else ""
+
         # Run the query
         compiler = query.get_compiler(self.db, connection=connection)
         data = compiler.execute_sql(csv_path)

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -170,7 +170,7 @@ class CopyQuerySet(ConstraintQuerySet):
 
         # Null string
         null_string = kwargs.get('null', None)
-        query.copy_to_null_string = "" if null_string is None else "NULL '{}'".format(null_string)
+        query.copy_to_null_string = "NULL '{}'".format(null_string) if null_string else ""
 
         # Quote character
         quote_char = kwargs.get('quote', None)

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -186,6 +186,10 @@ class CopyQuerySet(ConstraintQuerySet):
         set_encoding = kwargs.get('encoding', None)
         query.copy_to_encoding = "ENCODING '{}'".format(set_encoding) if set_encoding else ""
 
+        # Escape character
+        escape_char = kwargs.get('escape', None)
+        query.copy_to_escape = "ESCAPE '{}'".format(escape_char) if escape_char else ""
+
         # Run the query
         compiler = query.get_compiler(self.db, connection=connection)
         data = compiler.execute_sql(csv_path)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -143,12 +143,12 @@ class PostgresCopyToTest(BaseTest):
         )
 
         # Multiple columns passed as a list and force_quoted with pipes
-        MockObject.objects.to_csv(self.export_path, quote='|', force_quote=['NAME', 'NUMBER'])
+        MockObject.objects.to_csv(self.export_path, quote='|', force_quote=['NAME', 'DT'])
         self.assertTrue(os.path.exists(self.export_path))
         reader = csv.DictReader(open(self.export_path, 'r'))
         self.assertTrue(
-            [('|BEN|', '|1|'), ('|JOE|', '|2|'), ('|JANE|', '|3|')],
-            [(i['name'], i['number']) for i in reader]
+            [('|BEN|', '|2012-01-01|'), ('|JOE|', '|2012-01-02|'), ('|JANE|', '|2012-01-03|')],
+            [(i['name'], i['dt']) for i in reader]
         )
 
         # All columns force_quoted with pipes
@@ -171,9 +171,8 @@ class PostgresCopyToTest(BaseTest):
         MockObject.objects.to_csv(self.export_path, encoding='LATIN2')
 
         # Function should fail on known invalid inputs ('ASCII', 'utf-16')
-        with self.assertRaises(Exception):
-            MockObject.objects.to_csv(self.export_path, encoding='utf-16')
-            MockObject.objects.to_csv(self.export_path, encoding='ASCII')
+        self.assertRaises(Exception, MockObject.objects.to_csv(self.export_path), encoding='utf-16')
+        self.assertRaises(Exception, MockObject.objects.to_csv(self.export_path), encoding='ASCII')
 
     def test_export_escape_character(self):
         self._load_objects(self.name_path)
@@ -182,8 +181,7 @@ class PostgresCopyToTest(BaseTest):
         MockObject.objects.to_csv(self.export_path, escape='-')
 
         # Function should fail on known invalid inputs
-        with self.assertRaises(Exception):
-            MockObject.objects.to_csv(self.export_path, escape='--')
+        self.assertRaises(Exception, MockObject.objects.to_csv(self.export_path), escape='--')
 
     def test_filter(self):
         self._load_objects(self.name_path)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -130,7 +130,7 @@ class PostgresCopyToTest(BaseTest):
             [i['num'] for i in reader]
         )
 
-    def test_quote_character_and_force_quoting(self):
+    def test_export_quote_character_and_force_quoting(self):
         self._load_objects(self.name_path)
 
         # Single column being force_quoted with pipes
@@ -160,6 +160,30 @@ class PostgresCopyToTest(BaseTest):
             ['|BEN|', '|1|', '|2012-01-01|'],
             list(reader.values())[1:]
         )
+
+    def test_export_encoding(self):
+        self._load_objects(self.name_path)
+
+        # Function should pass on valid inputs ('utf-8', 'Unicode', 'LATIN2')
+        # If these don't raise an error, then they passed nicely
+        MockObject.objects.to_csv(self.export_path, encoding='utf-8')
+        MockObject.objects.to_csv(self.export_path, encoding='Unicode')
+        MockObject.objects.to_csv(self.export_path, encoding='LATIN2')
+
+        # Function should fail on known invalid inputs ('ASCII', 'utf-16')
+        with self.assertRaises(Exception):
+            MockObject.objects.to_csv(self.export_path, encoding='utf-16')
+            MockObject.objects.to_csv(self.export_path, encoding='ASCII')
+
+    def test_export_escape_character(self):
+        self._load_objects(self.name_path)
+
+        # Function should not fail on known valid inputs
+        MockObject.objects.to_csv(self.export_path, escape='-')
+
+        # Function should fail on known invalid inputs
+        with self.assertRaises(Exception):
+            MockObject.objects.to_csv(self.export_path, escape='--')
 
     def test_filter(self):
         self._load_objects(self.name_path)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -133,6 +133,7 @@ class PostgresCopyToTest(BaseTest):
     def test_quote_character_and_force_quoting(self):
         self._load_objects(self.name_path)
 
+        # Single column being force_quoted with pipes
         MockObject.objects.to_csv(self.export_path, quote='|', force_quote='NAME')
         self.assertTrue(os.path.exists(self.export_path))
         reader = csv.DictReader(open(self.export_path, 'r'))
@@ -141,6 +142,7 @@ class PostgresCopyToTest(BaseTest):
             [i['name'] for i in reader]
         )
 
+        # Multiple columns passed as a list and force_quoted with pipes
         MockObject.objects.to_csv(self.export_path, quote='|', force_quote=['NAME', 'NUMBER'])
         self.assertTrue(os.path.exists(self.export_path))
         reader = csv.DictReader(open(self.export_path, 'r'))
@@ -149,13 +151,14 @@ class PostgresCopyToTest(BaseTest):
             [(i['name'], i['number']) for i in reader]
         )
 
+        # All columns force_quoted with pipes
         MockObject.objects.to_csv(self.export_path, quote='|', force_quote='*')
         self.assertTrue(os.path.exists(self.export_path))
         reader = csv.DictReader(open(self.export_path, 'r'))
         reader = next(reader)
         self.assertTrue(
             ['|BEN|', '|1|', '|2012-01-01|'],
-            list(reader.values())
+            list(reader.values())[1:]
         )
 
     def test_filter(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -130,6 +130,34 @@ class PostgresCopyToTest(BaseTest):
             [i['num'] for i in reader]
         )
 
+    def test_quote_character_and_force_quoting(self):
+        self._load_objects(self.name_path)
+
+        MockObject.objects.to_csv(self.export_path, quote='|', force_quote='NAME')
+        self.assertTrue(os.path.exists(self.export_path))
+        reader = csv.DictReader(open(self.export_path, 'r'))
+        self.assertTrue(
+            ['|BEN|', '|JOE|', '|JANE|'],
+            [i['name'] for i in reader]
+        )
+
+        MockObject.objects.to_csv(self.export_path, quote='|', force_quote=['NAME', 'NUMBER'])
+        self.assertTrue(os.path.exists(self.export_path))
+        reader = csv.DictReader(open(self.export_path, 'r'))
+        self.assertTrue(
+            [('|BEN|', '|1|'), ('|JOE|', '|2|'), ('|JANE|', '|3|')],
+            [(i['name'], i['number']) for i in reader]
+        )
+
+        MockObject.objects.to_csv(self.export_path, quote='|', force_quote='*')
+        self.assertTrue(os.path.exists(self.export_path))
+        reader = csv.DictReader(open(self.export_path, 'r'))
+        reader = next(reader)
+        self.assertTrue(
+            ['|BEN|', '|1|', '|2012-01-01|'],
+            list(reader.values())
+        )
+
     def test_filter(self):
         self._load_objects(self.name_path)
         MockObject.objects.filter(name="BEN").to_csv(self.export_path)


### PR DESCRIPTION
Added the kwargs that were missing in copy_to. I successfully checked their functionality on a shell and against the commands run directly on a psql shell. I understand these need to come with tests, I will be writing them in the next days. 

However I have a few doubts as to how to test them:

- `quote` and `force_quote` are easily tested together. I actually don't know how to test `quote` without `force_quote`
- `encoding` works fine with 'utf-8' and 'Unicode', everything else I try fails ('ASCII', 'utf-16'). I tested these values on a psql shell so I know my implementation is working correctly, but how can we test the output of `to_csv`?
- `escape` I literally don't understand it. The only effect I have noticed is using '-' as an escape character and watching dates "2010-01-01" turn into "2018--01--01" (double hyphen)

Documentation incoming as well.