### PR TITLE
added logic for more verbose error messages on copy_from failures

### DIFF
--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -166,7 +166,7 @@ class CopyMapping(object):
         Raises errors if something goes wrong. Returns nothing if everything is kosher.
         """
         # Get the model name for a more verbose output on error
-        _model_name = str(self.model._meta).split(sep='.')[1]
+        _model_name = str(self.model._meta).split('.')[1]
 
         # Make sure all of the CSV headers in the mapping actually exist
         failing_headers = []

--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -173,46 +173,30 @@ class CopyMapping(object):
         for map_header in self.mapping.values():
             if map_header not in self.headers:
                 failing_headers.append(map_header)
-        if len(failing_headers) == 1:
-            raise ValueError("Header '{}' not found in CSV file.".format(failing_headers[0]))
-        elif len(failing_headers) > 1:
+        if len(failing_headers) >= 1:
             raise ValueError("Headers '{}' not found in CSV file.".format(
                 "', '".join(h for h in failing_headers)
                 ))
-        else:
-            pass
 
         # Make sure all the model fields in the mapping actually exist
         failing_fields = []
         for map_field in self.mapping.keys():
             if not self.get_field(map_field):
                 failing_fields.append(map_field)
-        if len(failing_fields) == 1:
-            raise FieldDoesNotExist("Model '{}' does not include field '{}'.".format(
-                _model_name, failing_fields[0]
-                ))
-        elif len(failing_fields) > 1:
+        if len(failing_fields) >= 1:
             raise FieldDoesNotExist("Model '{}' does not include fields '{}'.".format(
                 _model_name, "', '".join(f for f in failing_fields)
                 ))
-        else:
-            pass
 
         # Make sure any static mapping columns exist
         failing_static = []
         for static_field in self.static_mapping.keys():
             if not self.get_field(static_field):
                 failing_static.append(static_field)
-        if len(failing_static) == 1:
-            raise ValueError("Model '{}' does not include field '{}'.".format(
-                _model_name, failing_static[0]
-                ))
-        elif len(failing_static) > 1:
+        if len(failing_static) >= 1:
             raise ValueError("Model '{}' does not include fields '{}'.".format(
                 _model_name, "', '".join(s for s in failing_static)
                 ))
-        else:
-            pass
 
     #
     # CREATE commands

--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -165,20 +165,54 @@ class CopyMapping(object):
 
         Raises errors if something goes wrong. Returns nothing if everything is kosher.
         """
+        # Get the model name for a more verbose output on error
+        _model_name = str(self.model._meta).split(sep='.')[1]
+
         # Make sure all of the CSV headers in the mapping actually exist
+        failing_headers = []
         for map_header in self.mapping.values():
             if map_header not in self.headers:
-                raise ValueError("Header '{}' not found in CSV file".format(map_header))
+                failing_headers.append(map_header)
+        if len(failing_headers) == 1:
+            raise ValueError("Header '{}' not found in CSV file.".format(failing_headers[0]))
+        elif len(failing_headers) > 1:
+            raise ValueError("Headers '{}' not found in CSV file.".format(
+                "', '".join(h for h in failing_headers)
+                ))
+        else:
+            pass
 
         # Make sure all the model fields in the mapping actually exist
+        failing_fields = []
         for map_field in self.mapping.keys():
             if not self.get_field(map_field):
-                raise FieldDoesNotExist("Model does not include {} field".format(map_field))
+                failing_fields.append(map_field)
+        if len(failing_fields) == 1:
+            raise FieldDoesNotExist("Model '{}' does not include field '{}'.".format(
+                _model_name, failing_fields[0]
+                ))
+        elif len(failing_fields) > 1:
+            raise FieldDoesNotExist("Model '{}' does not include fields '{}'.".format(
+                _model_name, "', '".join(f for f in failing_fields)
+                ))
+        else:
+            pass
 
         # Make sure any static mapping columns exist
+        failing_static = []
         for static_field in self.static_mapping.keys():
             if not self.get_field(static_field):
-                raise ValueError("Model does not include {} field".format(static_field))
+                failing_static.append(static_field)
+        if len(failing_static) == 1:
+            raise ValueError("Model '{}' does not include field '{}'.".format(
+                _model_name, failing_static[0]
+                ))
+        elif len(failing_static) > 1:
+            raise ValueError("Model '{}' does not include fields '{}'.".format(
+                _model_name, "', '".join(s for s in failing_static)
+                ))
+        else:
+            pass
 
     #
     # CREATE commands

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -645,7 +645,8 @@ class PostgresCopyFromTest(BaseTest):
                 static_mapping=dict(static_bad=1)
             )
 
-    def test_bad_static_values_error_msg(self):
+    @mock.patch("django.db.connection.validate_no_atomic_block")
+    def test_bad_static_values_error_msg(self, _):
         with self.assertRaisesRegex(ValueError, "Model 'extendedmockobject' does not include fields 'static_bad'."):
             ExtendedMockObject.objects.from_csv(
                 self.name_path,
@@ -653,7 +654,8 @@ class PostgresCopyFromTest(BaseTest):
                 static_mapping=dict(static_bad=1)
             )
 
-    def test_multiple_bad_static_values_error_msg(self):
+    @mock.patch("django.db.connection.validate_no_atomic_block")
+    def test_multiple_bad_static_values_error_msg(self, _):
         check_words = ['extendedmockobject', 'static_bad1', 'static_bad2']
         for word in check_words:
             with self.assertRaisesRegex(ValueError, "{}".format(word)):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -328,7 +328,7 @@ class PostgresCopyFromTest(BaseTest):
             )
 
     def test_bad_header_error_msg(self):
-        with self.assertRaisesRegex(ValueError, "Header 'NAME1' not found in CSV file."):
+        with self.assertRaisesRegex(ValueError, "Headers 'NAME1' not found in CSV file."):
             CopyMapping(
                 MockObject,
                 self.name_path,
@@ -354,7 +354,7 @@ class PostgresCopyFromTest(BaseTest):
             )
 
     def test_bad_field_error_msg(self):
-        with self.assertRaisesRegex(FieldDoesNotExist, "Model 'mockobject' does not include field 'name1'."):
+        with self.assertRaisesRegex(FieldDoesNotExist, "Model 'mockobject' does not include fields 'name1'."):
             CopyMapping(
                 MockObject,
                 self.name_path,
@@ -646,7 +646,7 @@ class PostgresCopyFromTest(BaseTest):
             )
 
     def test_bad_static_values_error_msg(self):
-        with self.assertRaisesRegex(ValueError, "Model 'extendedmockobject' does not include field 'static_bad'."):
+        with self.assertRaisesRegex(ValueError, "Model 'extendedmockobject' does not include fields 'static_bad'."):
             ExtendedMockObject.objects.from_csv(
                 self.name_path,
                 dict(name='NAME', number='NUMBER', dt='DATE'),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,6 +28,7 @@ from django.core.exceptions import FieldDoesNotExist
 class BaseTest(TestCase):
 
     if sys.version_info.major == 2:
+        import unittest
         assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
     def setUp(self):
@@ -335,12 +336,14 @@ class PostgresCopyFromTest(BaseTest):
             )
 
     def test_multiple_bad_headers_error_msg(self):
-        with self.assertRaisesRegex(ValueError, "Headers 'NAME1', 'NUMBER1' not found in CSV file."):
-            CopyMapping(
-                MockObject,
-                self.name_path,
-                OrderedDict(name='NAME1', number='NUMBER1', dt='DATE'),
-            )
+        check_words = ['NAME1', 'NUMBER1']
+        for word in check_words:
+            with self.assertRaisesRegex(ValueError, "{}".format(word)):
+                CopyMapping(
+                    MockObject,
+                    self.name_path,
+                    OrderedDict(name='NAME1', number='NUMBER1', dt='DATE'),
+                )
 
     def test_bad_field(self):
         with self.assertRaises(FieldDoesNotExist):
@@ -359,12 +362,14 @@ class PostgresCopyFromTest(BaseTest):
             )
 
     def test_multiple_bad_fields_error_msg(self):
-        with self.assertRaisesRegex(FieldDoesNotExist, "Model 'mockobject' does not include fields 'name1', 'number1'."):
-            CopyMapping(
-                MockObject,
-                self.name_path,
-                OrderedDict(name1='NAME', number1='NUMBER', dt='DATE'),
-            )
+        check_words = ['mockobject', 'name1', 'number1']
+        for word in check_words:
+            with self.assertRaisesRegex(FieldDoesNotExist, "{}".format(word)):
+                CopyMapping(
+                    MockObject,
+                    self.name_path,
+                    OrderedDict(name1='NAME', number1='NUMBER', dt='DATE'),
+                )
 
     def test_limited_fields(self):
         CopyMapping(
@@ -649,12 +654,14 @@ class PostgresCopyFromTest(BaseTest):
             )
 
     def test_multiple_bad_static_values_error_msg(self):
-        with self.assertRaisesRegex(ValueError, "Model 'extendedmockobject' does not include fields 'static_bad1', 'static_bad2'."):
-            ExtendedMockObject.objects.from_csv(
-                self.name_path,
-                dict(name='NAME', number='NUMBER', dt='DATE'),
-                static_mapping=OrderedDict(static_bad1=1, static_bad2=2)
-            )
+        check_words = ['extendedmockobject', 'static_bad1', 'static_bad2']
+        for word in check_words:
+            with self.assertRaisesRegex(ValueError, "{}".format(word)):
+                ExtendedMockObject.objects.from_csv(
+                    self.name_path,
+                    dict(name='NAME', number='NUMBER', dt='DATE'),
+                    static_mapping=OrderedDict(static_bad1=1, static_bad2=2)
+                )
 
     @mock.patch("django.db.connection.validate_no_atomic_block")
     def test_overload_save(self, _):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -321,12 +321,44 @@ class PostgresCopyFromTest(BaseTest):
                 dict(name='NAME1', number='NUMBER', dt='DATE'),
             )
 
+    def test_bad_header_error_msg(self):
+        with self.assertRaisesRegex(ValueError, "Header 'NAME1' not found in CSV file."):
+            CopyMapping(
+                MockObject,
+                self.name_path,
+                dict(name='NAME1', number='NUMBER', dt='DATE'),
+            )
+
+    def test_multiple_bad_headers_error_msg(self):
+        with self.assertRaisesRegex(ValueError, "Headers 'NAME1', 'NUMBER1' not found in CSV file."):
+            CopyMapping(
+                MockObject,
+                self.name_path,
+                dict(name='NAME1', number='NUMBER1', dt='DATE'),
+            )
+
     def test_bad_field(self):
         with self.assertRaises(FieldDoesNotExist):
             CopyMapping(
                 MockObject,
                 self.name_path,
                 dict(name1='NAME', number='NUMBER', dt='DATE'),
+            )
+
+    def test_bad_field_error_msg(self):
+        with self.assertRaisesRegex(FieldDoesNotExist, "Model 'mockobject' does not include field 'name1'."):
+            CopyMapping(
+                MockObject,
+                self.name_path,
+                dict(name1='NAME', number='NUMBER', dt='DATE'),
+            )
+
+    def test_multiple_bad_fields_error_msg(self):
+        with self.assertRaisesRegex(FieldDoesNotExist, "Model 'mockobject' does not include fields 'name1', 'number1'."):
+            CopyMapping(
+                MockObject,
+                self.name_path,
+                dict(name1='NAME', number1='NUMBER', dt='DATE'),
             )
 
     def test_limited_fields(self):
@@ -524,7 +556,7 @@ class PostgresCopyFromTest(BaseTest):
             date(2012, 1, 1)
         )
 
-    @mock.patch("django.db.connection.validate_no_atomic_block")                   
+    @mock.patch("django.db.connection.validate_no_atomic_block")
     def test_backwards_save(self, _):
         MockObject.objects.from_csv(
             self.backwards_path,
@@ -601,6 +633,22 @@ class PostgresCopyFromTest(BaseTest):
                 dict(name='NAME', number='NUMBER', dt='DATE'),
                 encoding='UTF-8',
                 static_mapping=dict(static_bad=1)
+            )
+
+    def test_bad_static_values_error_msg(self):
+        with self.assertRaisesRegex(ValueError, "Model 'extendedmockobject' does not include field 'static_bad'."):
+            ExtendedMockObject.objects.from_csv(
+                self.name_path,
+                dict(name='NAME', number='NUMBER', dt='DATE'),
+                static_mapping=dict(static_bad=1)
+            )
+
+    def test_multiple_bad_static_values_error_msg(self):
+        with self.assertRaisesRegex(ValueError, "Model 'extendedmockobject' does not include fields 'static_bad1', 'static_bad2'."):
+            ExtendedMockObject.objects.from_csv(
+                self.name_path,
+                dict(name='NAME', number='NUMBER', dt='DATE'),
+                static_mapping=dict(static_bad1=1, static_bad2=2)
             )
 
     @mock.patch("django.db.connection.validate_no_atomic_block")
@@ -687,7 +735,7 @@ class PostgresCopyFromTest(BaseTest):
 
 
 class MultiDbTest(BaseTest):
-    @mock.patch("django.db.connection.validate_no_atomic_block") 
+    @mock.patch("django.db.connection.validate_no_atomic_block")
     def test_from_csv(self, _):
         MockObject.objects.from_csv(
             self.name_path,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,8 @@ import io
 import mock
 import os
 import csv
+import sys
+from collections import OrderedDict
 from datetime import date
 from .models import (
     MockObject,
@@ -24,6 +26,9 @@ from django.core.exceptions import FieldDoesNotExist
 
 
 class BaseTest(TestCase):
+
+    if sys.version_info.major == 2:
+        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
     def setUp(self):
         self.data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -334,7 +339,7 @@ class PostgresCopyFromTest(BaseTest):
             CopyMapping(
                 MockObject,
                 self.name_path,
-                dict(name='NAME1', number='NUMBER1', dt='DATE'),
+                OrderedDict(name='NAME1', number='NUMBER1', dt='DATE'),
             )
 
     def test_bad_field(self):
@@ -358,7 +363,7 @@ class PostgresCopyFromTest(BaseTest):
             CopyMapping(
                 MockObject,
                 self.name_path,
-                dict(name1='NAME', number1='NUMBER', dt='DATE'),
+                OrderedDict(name1='NAME', number1='NUMBER', dt='DATE'),
             )
 
     def test_limited_fields(self):
@@ -648,7 +653,7 @@ class PostgresCopyFromTest(BaseTest):
             ExtendedMockObject.objects.from_csv(
                 self.name_path,
                 dict(name='NAME', number='NUMBER', dt='DATE'),
-                static_mapping=dict(static_bad1=1, static_bad2=2)
+                static_mapping=OrderedDict(static_bad1=1, static_bad2=2)
             )
 
     @mock.patch("django.db.connection.validate_no_atomic_block")


### PR DESCRIPTION
Resolves #79 

Any inputs on how to write tests for these or if tests are necessary in the first place? As far as I know `assertRaises` cares about the exception only and not the message and all I'm really doing in this commit is manipulating the message string.