### PR TITLE
Enforce kwagrs

### DIFF
--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -154,8 +154,7 @@ class CopyQuerySet(ConstraintQuerySet):
         quote=None,
         force_quote=None,
         encoding=None,
-        escape=None,
-        ):
+        escape=None):
         """
         Copy current QuerySet to CSV at provided path.
         """

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -147,7 +147,15 @@ class CopyQuerySet(ConstraintQuerySet):
 
         return insert_count
 
-    def to_csv(self, csv_path=None, *fields, **kwargs):
+    def to_csv(self, csv_path=None, *fields,
+        delimiter=',',
+        header = True,
+        null = None,
+        quote = None,
+        force_quote = None,
+        encoding = None,
+        escape = None,
+        ):
         """
         Copy current QuerySet to CSV at provided path.
         """
@@ -162,22 +170,18 @@ class CopyQuerySet(ConstraintQuerySet):
         query.copy_to_fields = fields
 
         # Delimiter
-        query.copy_to_delimiter = "DELIMITER '{}'".format(kwargs.get('delimiter', ','))
+        query.copy_to_delimiter = "DELIMITER '{}'".format(delimiter)
 
         # Header
-        with_header = kwargs.get('header', True)
-        query.copy_to_header = "HEADER" if with_header else ""
+        query.copy_to_header = "HEADER" if header else ""
 
         # Null string
-        null_string = kwargs.get('null', None)
-        query.copy_to_null_string = "NULL '{}'".format(null_string) if null_string else ""
+        query.copy_to_null_string = "NULL '{}'".format(null) if null else ""
 
         # Quote character
-        quote_char = kwargs.get('quote', None)
-        query.copy_to_quote_char = "QUOTE '{}'".format(quote_char) if quote_char else ""
+        query.copy_to_quote_char = "QUOTE '{}'".format(quote) if quote else ""
 
         # Force quote on columns
-        force_quote = kwargs.get('force_quote', None)
         if force_quote:
             # If it's a list of fields, pass them in with commas
             if type(force_quote) == list:
@@ -193,12 +197,10 @@ class CopyQuerySet(ConstraintQuerySet):
             query.copy_to_force_quote = ""
 
         # Encoding
-        set_encoding = kwargs.get('encoding', None)
-        query.copy_to_encoding = "ENCODING '{}'".format(set_encoding) if set_encoding else ""
+        query.copy_to_encoding = "ENCODING '{}'".format(encoding) if encoding else ""
 
         # Escape character
-        escape_char = kwargs.get('escape', None)
-        query.copy_to_escape = "ESCAPE '{}'".format(escape_char) if escape_char else ""
+        query.copy_to_escape = "ESCAPE '{}'".format(escape) if escape else ""
 
         # Run the query
         compiler = query.get_compiler(self.db, connection=connection)

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -149,12 +149,12 @@ class CopyQuerySet(ConstraintQuerySet):
 
     def to_csv(self, csv_path=None, *fields,
         delimiter=',',
-        header = True,
-        null = None,
-        quote = None,
-        force_quote = None,
-        encoding = None,
-        escape = None,
+        header=True,
+        null=None,
+        quote=None,
+        force_quote=None,
+        encoding=None,
+        escape=None,
         ):
         """
         Copy current QuerySet to CSV at provided path.


### PR DESCRIPTION
I know this will fail on python 2.7 but I'm throwing it out there in case you wish to consider it.

Not enforcing keyword arguments makes `copy_to` prone to silent errors. A typo on any of the keyword arguments will not raise an error and the user might not notice it didn't work as intended.

For example, a user that wishes to do `encoding='utf-8'`, but mistypes `encoding` as, say, `ecnoding` is likely to never realize the mistake, especially with keyword arguments whose effect on the data is not obvious to the eye.

Considering keyword arguments are limited by whatever arguments Postgres' `COPY` command accepts, there's no reason, in my opinion, to leave them open with `**` other than to preserve compatibility with python 2.x.