### PR TITLE
Change psycopg2 to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies
 Django
-psycopg2
+psycopg2-binary
 
 # Docs
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     url='http://django-postgres-copy.californiacivicdata.org/',
     license="MIT",
     packages=("postgres_copy",),
-    install_requires=("psycopg2>=2.7.3",),
+    install_requires=("psycopg2-binary>=2.7.3",),
     cmdclass={'test': TestCommand},
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
After a fresh installation the following warning is displayed:

```
UserWarning: The psycopg2 wheel package will be renamed from release 2.8;
in order to keep installing from binary please use "pip install psycopg2-binary" instead.
For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```

This commit fixes that using `psycopg2-binary` in place of `psycopg2` as the name of the Psycopg2 dependency.