### PR TITLE
Allow `to_csv` to write to a file-like object

### DIFF
--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -66,8 +66,12 @@ class SQLCopyToCompiler(SQLCompiler):
             # then execute
             logger.debug(copy_to_sql)
 
-            # If there is, write it out there.
-            if csv_path:
+            # If a file-like object was provided, write it out there.
+            if hasattr(csv_path, 'write'):
+                c.cursor.copy_expert(copy_to_sql, csv_path)
+                return
+            # If a file path was provided, write it out there.
+            elif csv_path:
                 with open(csv_path, 'wb') as stdout:
                     c.cursor.copy_expert(copy_to_sql, stdout)
                     return

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -149,7 +149,7 @@ class CopyQuerySet(ConstraintQuerySet):
 
     def to_csv(self, csv_path=None, *fields, **kwargs):
         """
-        Copy current QuerySet to CSV at provided path.
+        Copy current QuerySet to CSV at provided path or file-like object.
         """
         try:
             # For Django 2.0 forward

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,7 @@
 import os
 import csv
 from datetime import date
+import io
 from .models import (
     MockObject,
     MockFKObject,
@@ -48,6 +49,7 @@ class PostgresCopyToTest(BaseTest):
     def setUp(self):
         super(PostgresCopyToTest, self).setUp()
         self.export_path = os.path.join(os.path.dirname(__file__), 'export.csv')
+        self.export_file = io.StringIO()
 
     def tearDown(self):
         super(PostgresCopyToTest, self).tearDown()
@@ -65,6 +67,15 @@ class PostgresCopyToTest(BaseTest):
         MockObject.objects.to_csv(self.export_path)
         self.assertTrue(os.path.exists(self.export_path))
         reader = csv.DictReader(open(self.export_path, 'r'))
+        self.assertTrue(
+            ['BEN', 'JOE', 'JANE'],
+            [i['name'] for i in reader]
+        )
+
+    def test_export_to_file(self):
+        self._load_objects(self.name_path)
+        MockObject.objects.to_csv(self.export_file)
+        reader = csv.DictReader(self.export_file)
         self.assertTrue(
             ['BEN', 'JOE', 'JANE'],
             [i['name'] for i in reader]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -85,9 +85,9 @@ class PostgresCopyToTest(BaseTest):
         self._load_objects(self.name_path)
         export = MockObject.objects.to_csv()
         self.assertEqual(export, b"""id,name,num,dt,parent_id
-83,BEN,1,2012-01-01,
-84,JOE,2,2012-01-02,
-85,JANE,3,2012-01-03,
+86,BEN,1,2012-01-01,
+87,JOE,2,2012-01-02,
+88,JANE,3,2012-01-03,
 """)
 
     def test_export_header_setting(self):


### PR DESCRIPTION
Fixes #87.

Here's a first pass at adding this as we discussed in the issue. Does a `hasattr` check for `write`-ness. Had to tweak some things in the tests due to this changing the IDs in the test database, but I think I got it.