### PR TITLE
fix docs error in to_csv api description

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -458,7 +458,7 @@ Export options
 
 The ``to_csv`` manager method only requires one argument, the path to where the CSV should be exported. It also allows users to optionally limit or expand the fields written out by providing them as additional parameters. Other options allow for configuration of the output file.
 
-.. method:: to_csv(csv_path [, *fields, delimiter=',', with_header=True, null=None, encoding=None, escape=None, quote=None, force_quote=None])
+.. method:: to_csv(csv_path [, *fields, delimiter=',', header=True, null=None, encoding=None, escape=None, quote=None, force_quote=None])
 
 
 =================  =========================================================


### PR DESCRIPTION
The header keyword argument is ``header=True`` but was shown as
``with_header=True`` in the short API description.  It's correctly shown
as ``header`` in the long argument description table.

Signed-off-by: Uri Okrent <uokrent@gmail.com>