### PR TITLE
Better error message when trying to drop constraints/indexes in a transaction block

### DIFF
--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -131,6 +131,13 @@ class CopyQuerySet(ConstraintQuerySet):
         """
         Copy CSV file from the provided path to the current model using the provided mapping.
         """
+        # Dropping constraints or indices will fail with an opaque error for all but
+        # very trivial databases (e.g., those with no constraints or indices), if 
+        # we are in a transaction block and throw an opaque error.  So, we prevent
+        # the user from even trying to avoid confusion.
+        if drop_constraints or drop_indexes:
+          connection.validate_no_atomic_block()
+
         mapping = CopyMapping(self.model, csv_path, mapping, **kwargs)
 
         if drop_constraints:

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -132,11 +132,10 @@ class CopyQuerySet(ConstraintQuerySet):
         Copy CSV file from the provided path to the current model using the provided mapping.
         """
         # Dropping constraints or indices will fail with an opaque error for all but
-        # very trivial databases (e.g., those with no constraints or indices), if 
-        # we are in a transaction block and throw an opaque error.  So, we prevent
-        # the user from even trying to avoid confusion.
+        # very trivial databases which wouldn't benefit from this optimization anyway.
+        # So, we prevent the user from even trying to avoid confusion.
         if drop_constraints or drop_indexes:
-          connection.validate_no_atomic_block()
+            connection.validate_no_atomic_block()
 
         mapping = CopyMapping(self.model, csv_path, mapping, **kwargs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ flake8
 coverage
 python-coveralls
 tox
+mock

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -70,6 +70,11 @@ class PostgresCopyToTest(BaseTest):
     def _load_secondary_objects(self, file_path, mapping=dict(text='TEXT')):
         SecondaryMockObject.objects.from_csv(file_path, mapping)
 
+    # These tests are using simple enough databases that they can safely proceed
+    # with uploading objects from CSV despite being within a transaction block.
+    # In particular, Django wraps all tests in a transaction so that database
+    # changes can be rolled back.  Therefore, we bypass validate_no_atomic_block
+    # here and elsewhere.
     @mock.patch("django.db.connection.validate_no_atomic_block")
     def test_export(self, _):
         self._load_objects(self.name_path)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,6 +14,7 @@ from .models import (
     UniqueMockObject
 )
 from django.test import TestCase
+from django.db.transaction import TransactionManagementError
 from django.db.models import Count
 from postgres_copy import CopyMapping
 from django.core.exceptions import FieldDoesNotExist
@@ -325,6 +326,19 @@ class PostgresCopyFromTest(BaseTest):
             date(2012, 1, 1)
         )
 
+    def test_atomic_block:(self):
+        with transaction.atomic():
+            try:
+                f = open(self.name_path, 'r')
+                MockObject.objects.from_csv(
+                    f,
+                    dict(name='NAME', number='NUMBER', dt='DATE')
+                )
+                self.fail("Expected TransactionManagementError.")
+            except TransactionManagementError:
+                # Expected
+                pass
+
     def test_simple_save(self):
         insert_count = MockObject.objects.from_csv(
             self.name_path,
@@ -630,7 +644,6 @@ class PostgresCopyFromTest(BaseTest):
 
 
 class MultiDbTest(BaseTest):
-
     def test_from_csv(self):
         MockObject.objects.from_csv(
             self.name_path,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -326,7 +326,7 @@ class PostgresCopyFromTest(BaseTest):
             date(2012, 1, 1)
         )
 
-    def test_atomic_block:(self):
+    def test_atomic_block(self):
         with transaction.atomic():
             try:
                 f = open(self.name_path, 'r')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -218,7 +218,7 @@ class PostgresCopyToTest(BaseTest):
         self.assertRaises(Exception, MockObject.objects.to_csv(self.export_path), escape='--')
 
     @mock.patch("django.db.connection.validate_no_atomic_block")
-    def test_filter(self):
+    def test_filter(self, _):
         self._load_objects(self.name_path)
         MockObject.objects.filter(name="BEN").to_csv(self.export_path)
         reader = csv.DictReader(open(self.export_path, 'r'))
@@ -510,7 +510,7 @@ class PostgresCopyFromTest(BaseTest):
         )
 
     @mock.patch("django.db.connection.validate_no_atomic_block")
-    def test_force_null_save(self):
+    def test_force_null_save(self, _):
         MockObject.objects.from_csv(
             self.null_path,
             dict(name='NAME', number='NUMBER', dt='DATE'),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -217,6 +217,7 @@ class PostgresCopyToTest(BaseTest):
         # Function should fail on known invalid inputs
         self.assertRaises(Exception, MockObject.objects.to_csv(self.export_path), escape='--')
 
+    @mock.patch("django.db.connection.validate_no_atomic_block")
     def test_filter(self):
         self._load_objects(self.name_path)
         MockObject.objects.filter(name="BEN").to_csv(self.export_path)
@@ -508,6 +509,7 @@ class PostgresCopyFromTest(BaseTest):
             date(2012, 1, 1)
         )
 
+    @mock.patch("django.db.connection.validate_no_atomic_block")
     def test_force_null_save(self):
         MockObject.objects.from_csv(
             self.null_path,


### PR DESCRIPTION
This will fail with an opaque error for all but very trivial databases, so we throw a more meaningful error right away instead of letting this fail at the point of dropping constraints/indexes in order to avoid confusion.

#95 