### PR TITLE
Support binary mode of file-like objects passed to from_csv()

### DIFF
--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -6,6 +6,7 @@ Handlers for working with PostgreSQL's COPY command.
 import os
 import sys
 import logging
+from six import ensure_binary, ensure_str
 from collections import OrderedDict
 from django.db import NotSupportedError
 from django.db import connections, router
@@ -160,13 +161,11 @@ class CopyMapping(object):
         encoding = self.encoding or 'utf-8'
         # if file is in binary mode...
         if 'b' in file_mode:
-            # ...make sure the delimiter is cast as bytes...
-            delimiter = bytes(
-                self.delimiter, encoding=encoding
-            )
-            # ...and each header item is a str (whitespace stripped)
+            # ...coerce delimiter to binary...
+            delimiter = ensure_binary(self.delimiter, encoding=encoding)
+            # ...and coerce each header item to str (and strip whitespace)
             headers = [
-                str(h, encoding=encoding).strip()
+                ensure_str(h, encoding=encoding).strip()
                 for h in self.csv_file.readline().split(delimiter)
             ]
         # if not in binary mode...

--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -158,18 +158,28 @@ class CopyMapping(object):
         )
         # take the user-defined encoding, or assume utf-8
         encoding = self.encoding or 'utf-8'
-        # if file is in binary mode, make sure the delimiter is cast as bytes
-        if 'b' in file_mode and isinstance(self.delimiter, str):
-            delimiter = bytes(
-                self.delimiter, encoding=encoding
-            )
+        # if file is in binary mode...
+        if 'b' in file_mode:
+            # ...make sure the delimiter is cast as bytes...
+            if isinstance(self.delimiter, str):
+                delimiter = bytes(
+                    self.delimiter, encoding=encoding
+                )
+            else:
+                delimiter = self.delimiter
+            # ...and each header item is a str (whitespace stripped)
+            headers = [
+                str(h, encoding=encoding).strip()
+                for h in self.csv_file.readline().split(delimiter)
+            ]
+        # if not in binary mode...
         else:
             delimiter = self.delimiter
-        # make sure each headers item is a str with whitespace stripped
-        headers = [
-            str(h, encoding=encoding).strip()
-            for h in self.csv_file.readline().split(delimiter)
-        ]
+            # ...just strip whitespace on each header item
+            headers = [
+                h.strip()
+                for h in self.csv_file.readline().split(delimiter)
+            ]
         # Move back to the top of the file
         self.csv_file.seek(0)
 

--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -6,12 +6,12 @@ Handlers for working with PostgreSQL's COPY command.
 import os
 import sys
 import logging
-from six import ensure_binary, ensure_str
 from collections import OrderedDict
 from django.db import NotSupportedError
 from django.db import connections, router
 from django.core.exceptions import FieldDoesNotExist
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.utils.encoding import force_bytes, force_text
 logger = logging.getLogger(__name__)
 
 
@@ -162,10 +162,10 @@ class CopyMapping(object):
         # if file is in binary mode...
         if 'b' in file_mode:
             # ...coerce delimiter to binary...
-            delimiter = ensure_binary(self.delimiter, encoding=encoding)
+            delimiter = force_bytes(self.delimiter, encoding=encoding)
             # ...and coerce each header item to str (and strip whitespace)
             headers = [
-                ensure_str(h, encoding=encoding).strip()
+                force_text(h, encoding=encoding).strip()
                 for h in self.csv_file.readline().split(delimiter)
             ]
         # if not in binary mode...

--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -5,7 +5,6 @@ Handlers for working with PostgreSQL's COPY command.
 """
 import os
 import sys
-import csv
 import logging
 from collections import OrderedDict
 from django.db import NotSupportedError
@@ -150,13 +149,30 @@ class CopyMapping(object):
         Returns the column headers from the csv as a list.
         """
         logger.debug("Retrieving headers from {}".format(self.csv_file))
-        # Open it as a CSV
-        csv_reader = csv.reader(self.csv_file, delimiter=self.delimiter)
-        # Pop the headers
-        headers = next(csv_reader)
+
+        # determine what mode the file is opened in
+        file_mode = getattr(
+            self.csv_file, 'mode', getattr(
+                self.csv_file, '_mode', None
+            )
+        )
+        # take the user-defined encoding, or assume utf-8
+        encoding = self.encoding or 'utf-8'
+        # if file is in binary mode, make sure the delimiter is cast as bytes
+        if 'b' in file_mode and isinstance(self.delimiter, str):
+            delimiter = bytes(
+                self.delimiter, encoding=encoding
+            )
+        else:
+            delimiter = self.delimiter
+        # make sure each headers item is a str with whitespace stripped
+        headers = [
+            str(h, encoding=encoding).strip()
+            for h in self.csv_file.readline().split(delimiter)
+        ]
         # Move back to the top of the file
         self.csv_file.seek(0)
-        # Return the headers
+
         return headers
 
     def validate_mapping(self):

--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -161,12 +161,9 @@ class CopyMapping(object):
         # if file is in binary mode...
         if 'b' in file_mode:
             # ...make sure the delimiter is cast as bytes...
-            if isinstance(self.delimiter, str):
-                delimiter = bytes(
-                    self.delimiter, encoding=encoding
-                )
-            else:
-                delimiter = self.delimiter
+            delimiter = bytes(
+                self.delimiter, encoding=encoding
+            )
             # ...and each header item is a str (whitespace stripped)
             headers = [
                 str(h, encoding=encoding).strip()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -102,9 +102,9 @@ class PostgresCopyToTest(BaseTest):
         self._load_objects(self.name_path)
         export = MockObject.objects.to_csv()
         self.assertEqual(export, b"""id,name,num,dt,parent_id
-86,BEN,1,2012-01-01,
-87,JOE,2,2012-01-02,
-88,JANE,3,2012-01-03,
+89,BEN,1,2012-01-01,
+90,JOE,2,2012-01-02,
+91,JANE,3,2012-01-03,
 """)
 
     @mock.patch("django.db.connection.validate_no_atomic_block")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -350,6 +350,20 @@ class PostgresCopyFromTest(BaseTest):
             date(2012, 1, 1)
         )
 
+    @mock.patch("django.db.connection.validate_no_atomic_block")
+    def test_save_with_binary_fileobject(self, _):
+        f = open(self.name_path, 'rb')
+        MockObject.objects.from_csv(
+            f,
+            dict(name='NAME', number='NUMBER', dt='DATE')
+        )
+        self.assertEqual(MockObject.objects.count(), 3)
+        self.assertEqual(MockObject.objects.get(name='BEN').number, 1)
+        self.assertEqual(
+            MockObject.objects.get(name='BEN').dt,
+            date(2012, 1, 1)
+        )
+
     def test_atomic_block(self):
         with transaction.atomic():
             try:


### PR DESCRIPTION
See #105 

I also added a new test for this case.

Not sure why the values of the id column need to be updated in `PostgresCopyToTest.test_export_to_str()`. I guess because PK field on this db table isn't being reset between tests?

Tests are passing when I run them locally, but not on travis.ci. Looks like travis.ci tests have been failing since https://github.com/california-civic-data-coalition/django-postgres-copy/commit/af32b53e9042e2128707bfdbf08fdb9bffee3135, possibly because of the upgrade from postgres 9 to 10?