### PR TITLE
drop explicit dependency on psycopg2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ class TestCommand(Command):
 
 setup(
     name='django-postgres-copy',
-    version='2.4.2',
+    version='2.4.3',
     author='Ben Welsh',
     author_email='ben.welsh@gmail.com',
     url='http://django-postgres-copy.californiacivicdata.org/',
@@ -85,7 +85,6 @@ setup(
     long_description=read('README.rst'),
     license="MIT",
     packages=("postgres_copy",),
-    install_requires=("psycopg2>=2.8.1",),
     cmdclass={'test': TestCommand},
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
this will allow users to use this library with e.g. `psycopg2-binary`
instead. closes #124

the docs [already mention](https://django-postgres-copy.readthedocs.io/en/latest/#installation) that you need to have (django and) something like psycopg2 installed